### PR TITLE
Disable Auto-apply: expression caching in the workspace panel instead of duplicated state

### DIFF
--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/data_panel_wrapper.test.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/data_panel_wrapper.test.tsx
@@ -12,6 +12,7 @@ import { DragDropIdentifier } from '../../drag_drop';
 import { UiActionsStart } from 'src/plugins/ui_actions/public';
 import { mockStoreDeps, mountWithProvider } from '../../mocks';
 import { disableAutoApply } from '../../state_management/lens_slice';
+import { selectTriggerApplyChanges } from '../../state_management';
 
 describe('Data Panel Wrapper', () => {
   describe('Datasource data panel properties', () => {
@@ -59,28 +60,27 @@ describe('Data Panel Wrapper', () => {
     describe('setState', () => {
       it('applies state immediately when option true', async () => {
         lensStore.dispatch(disableAutoApply());
+        selectTriggerApplyChanges(lensStore.getState());
 
         const newDatasourceState = { age: 'new' };
         datasourceDataPanelProps.setState(newDatasourceState, { applyImmediately: true });
 
-        const lensState = lensStore.getState().lens;
-        expect(lensState.datasourceStates.activeDatasource.state).toEqual(newDatasourceState);
-        expect(lensState.appliedState?.datasourceStates.activeDatasource.state).toEqual(
+        expect(lensStore.getState().lens.datasourceStates.activeDatasource.state).toEqual(
           newDatasourceState
         );
+        expect(selectTriggerApplyChanges(lensStore.getState())).toBeTruthy();
       });
 
       it('does not apply state immediately when option false', async () => {
         lensStore.dispatch(disableAutoApply());
+        selectTriggerApplyChanges(lensStore.getState());
 
         const newDatasourceState = { age: 'new' };
         datasourceDataPanelProps.setState(newDatasourceState, { applyImmediately: false });
 
         const lensState = lensStore.getState().lens;
         expect(lensState.datasourceStates.activeDatasource.state).toEqual(newDatasourceState);
-        expect(lensState.appliedState?.datasourceStates.activeDatasource.state).not.toEqual(
-          newDatasourceState
-        );
+        expect(selectTriggerApplyChanges(lensStore.getState())).toBeFalsy();
       });
     });
   });

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/suggestion_panel.test.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/suggestion_panel.test.tsx
@@ -30,6 +30,7 @@ import {
   setToggleFullscreen,
   VisualizationState,
 } from '../../state_management';
+import { setChangesApplied } from '../../state_management/lens_slice';
 
 const SELECTORS = {
   APPLY_CHANGES_BUTTON: 'button[data-test-subj="lnsSuggestionApplyChanges"]',
@@ -132,12 +133,8 @@ describe('suggestion_panel', () => {
             something: 'changed',
           },
         } as VisualizationState,
-        // including appliedState signals that auto-apply has been disabled
-        appliedState: {
-          activeDatasourceId: 'foobar',
-          visualization: preloadedState.visualization as VisualizationState,
-          datasourceStates: preloadedState.datasourceStates as DatasourceStates,
-        },
+        changesApplied: false,
+        autoApplyDisabled: true,
       },
     });
 
@@ -147,9 +144,11 @@ describe('suggestion_panel', () => {
     instance.find(SELECTORS.APPLY_CHANGES_BUTTON).simulate('click');
 
     // check changes applied
-    const newLensState = lensStore.getState().lens;
-    expect(newLensState.appliedState?.visualization).toEqual(newLensState.visualization);
-    expect(newLensState.appliedState?.datasourceStates).toEqual(newLensState.datasourceStates);
+    expect(lensStore.dispatch).toHaveBeenCalledWith(applyChanges());
+
+    // simulate workspace panel behavior
+    lensStore.dispatch(setChangesApplied(true));
+    instance.update();
 
     // check UI updated
     expect(instance.exists(SELECTORS.APPLY_CHANGES_BUTTON)).toBeFalsy();

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.test.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.test.tsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { ReactExpressionRendererProps } from '../../../../../../../src/plugins/expressions/public';
-import { DatasourcePublicAPI, FramePublicAPI, Visualization } from '../../../types';
+import { FramePublicAPI, Visualization } from '../../../types';
 import {
   createMockVisualization,
   createMockDatasource,

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.test.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.test.tsx
@@ -742,7 +742,7 @@ describe('workspace_panel', () => {
     expect(instance.find(expressionRendererMock)).toHaveLength(0);
   });
 
-  it.skip('should NOT display errors for unapplied changes', async () => {
+  it('should NOT display errors for unapplied changes', async () => {
     // this test is important since we don't want the workspace panel to
     // display errors if the user has disabled auto-apply, messed something up,
     // but not yet applied their changes

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.test.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.test.tsx
@@ -273,6 +273,36 @@ describe('workspace_panel', () => {
   `);
   });
 
+  it('should allow empty workspace as initial render when auto-apply disabled', async () => {
+    mockVisualization.toExpression.mockReturnValue('testVis');
+    const framePublicAPI = createMockFramePublicAPI();
+    framePublicAPI.datasourceLayers = {
+      first: mockDatasource.publicAPIMock,
+    };
+
+    const mounted = await mountWithProvider(
+      <WorkspacePanel
+        {...defaultProps}
+        datasourceMap={{
+          testDatasource: mockDatasource,
+        }}
+        framePublicAPI={framePublicAPI}
+        visualizationMap={{
+          testVis: mockVisualization,
+        }}
+      />,
+      {
+        preloadedState: {
+          autoApplyDisabled: true,
+        },
+      }
+    );
+
+    instance = mounted.instance;
+
+    expect(instance.exists('[data-test-subj="empty-workspace"]')).toBeTruthy();
+  });
+
   it('should execute a trigger on expression event', async () => {
     const framePublicAPI = createMockFramePublicAPI();
     framePublicAPI.datasourceLayers = {

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
@@ -274,7 +274,8 @@ export const InnerWorkspacePanel = React.memo(function InnerWorkspacePanel({
   }
 
   const expressionExists = Boolean(expressionToRender);
-  if (expressionExists && !localState.initialRenderComplete) {
+  // null signals an empty workspace which should count as an initial render
+  if ((expressionExists || expressionToRender === null) && !localState.initialRenderComplete) {
     setLocalState((s) => ({ ...s, initialRenderComplete: true }));
   }
 

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
@@ -122,7 +122,6 @@ export const WorkspacePanel = React.memo(function WorkspacePanel(props: Workspac
   );
 });
 
-let finishedInitialRender: boolean;
 let lastApplyChangesCounter = 0;
 
 // Exported for testing purposes only.
@@ -149,15 +148,10 @@ export const InnerWorkspacePanel = React.memo(function InnerWorkspacePanel({
   const triggerApply = applyChangesCounter !== lastApplyChangesCounter;
   lastApplyChangesCounter = applyChangesCounter;
 
-  const shouldApplyChanges = autoApplyEnabled || !finishedInitialRender || triggerApply;
-
   const [expressionToRender, setExpressionToRender] = useState<string | null | undefined>();
+  const [finishedInitialRender, setFinishedInitialRender] = useState(false);
 
-  useEffect(() => {
-    return () => {
-      finishedInitialRender = false;
-    };
-  }, []);
+  const shouldApplyChanges = autoApplyEnabled || !finishedInitialRender || triggerApply;
 
   const { datasourceLayers } = framePublicAPI;
   const [localState, setLocalState] = useState<WorkspaceState>({
@@ -271,8 +265,8 @@ export const InnerWorkspacePanel = React.memo(function InnerWorkspacePanel({
   }, [expression, dispatchLens, expressionToRender]);
 
   const expressionExists = Boolean(expressionToRender);
-  if (expressionExists) {
-    finishedInitialRender = true;
+  if (expressionExists && !finishedInitialRender) {
+    setFinishedInitialRender(true);
   }
 
   useEffect(() => {

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
@@ -122,8 +122,6 @@ export const WorkspacePanel = React.memo(function WorkspacePanel(props: Workspac
   );
 });
 
-let lastApplyChangesCounter = 0;
-
 // Exported for testing purposes only.
 export const InnerWorkspacePanel = React.memo(function InnerWorkspacePanel({
   framePublicAPI,
@@ -145,11 +143,15 @@ export const InnerWorkspacePanel = React.memo(function InnerWorkspacePanel({
   const autoApplyEnabled = useLensSelector(selectAutoApplyEnabled);
   const applyChangesCounter = useLensSelector(selectApplyChangesCounter);
 
-  const triggerApply = applyChangesCounter !== lastApplyChangesCounter;
-  lastApplyChangesCounter = applyChangesCounter;
-
   const [expressionToRender, setExpressionToRender] = useState<string | null | undefined>();
   const [finishedInitialRender, setFinishedInitialRender] = useState(false);
+  const [lastApplyChangesCounter, setLastApplyChangesCounter] = useState(0);
+
+  const triggerApply = applyChangesCounter !== lastApplyChangesCounter;
+
+  if (triggerApply) {
+    setLastApplyChangesCounter(applyChangesCounter);
+  }
 
   const shouldApplyChanges = autoApplyEnabled || !finishedInitialRender || triggerApply;
 
@@ -373,7 +375,7 @@ export const InnerWorkspacePanel = React.memo(function InnerWorkspacePanel({
   };
 
   const renderVisualization = () => {
-    if (!expressionExists) {
+    if (expression === null) {
       return renderEmptyWorkspace();
     }
     return (

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
@@ -265,6 +265,10 @@ export const InnerWorkspacePanel = React.memo(function InnerWorkspacePanel({
     visualization.activeId,
   ]);
 
+  useEffect(() => {
+    dispatchLens(setSaveable(Boolean(_expression)));
+  }, [_expression, dispatchLens]);
+
   if (shouldApplyExpression) {
     expressionToRender = _expression;
   }
@@ -278,10 +282,6 @@ export const InnerWorkspacePanel = React.memo(function InnerWorkspacePanel({
   if ((expressionExists || expressionToRender === null) && !localState.initialRenderComplete) {
     setLocalState((s) => ({ ...s, initialRenderComplete: true }));
   }
-
-  useEffect(() => {
-    dispatchLens(setSaveable(expressionExists));
-  }, [expressionExists, dispatchLens]);
 
   const onEvent = useCallback(
     (event: ExpressionRendererEvent) => {

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
@@ -67,7 +67,7 @@ import {
   selectActiveDatasourceId,
   selectSearchSessionId,
   selectAutoApplyEnabled,
-  selectApplyChangesCounter,
+  selectTriggerApplyChanges,
 } from '../../../state_management';
 import type { LensInspector } from '../../../lens_inspector_service';
 import { inferTimeField } from '../../../utils';
@@ -92,7 +92,6 @@ interface WorkspaceState {
   }>;
   expandError: boolean;
   initialRenderComplete: boolean;
-  lastApplyChangesCounter: number;
 }
 
 const dropProps = {
@@ -144,12 +143,11 @@ export const InnerWorkspacePanel = React.memo(function InnerWorkspacePanel({
   const activeDatasourceId = useLensSelector(selectActiveDatasourceId);
   const datasourceStates = useLensSelector(selectDatasourceStates);
   const autoApplyEnabled = useLensSelector(selectAutoApplyEnabled);
-  const applyChangesCounter = useLensSelector(selectApplyChangesCounter);
+  const triggerApply = useLensSelector(selectTriggerApplyChanges);
 
   const [localState, setLocalState] = useState<WorkspaceState>({
     expressionBuildError: undefined,
     expandError: false,
-    lastApplyChangesCounter: 0,
     initialRenderComplete: false,
   });
 
@@ -158,12 +156,6 @@ export const InnerWorkspacePanel = React.memo(function InnerWorkspacePanel({
       expressionToRender = null;
     };
   }, []);
-
-  const triggerApply = applyChangesCounter !== localState.lastApplyChangesCounter;
-
-  if (triggerApply) {
-    setLocalState((s) => ({ ...s, lastApplyChangesCounter: applyChangesCounter }));
-  }
 
   const shouldApplyExpression =
     autoApplyEnabled || !localState.initialRenderComplete || triggerApply;

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
@@ -123,6 +123,7 @@ export const WorkspacePanel = React.memo(function WorkspacePanel(props: Workspac
 });
 
 let finishedInitialRender: boolean;
+let lastApplyChangesCounter = 0;
 
 // Exported for testing purposes only.
 export const InnerWorkspacePanel = React.memo(function InnerWorkspacePanel({
@@ -143,7 +144,12 @@ export const InnerWorkspacePanel = React.memo(function InnerWorkspacePanel({
   const activeDatasourceId = useLensSelector(selectActiveDatasourceId);
   const datasourceStates = useLensSelector(selectDatasourceStates);
   const autoApplyEnabled = useLensSelector(selectAutoApplyEnabled);
-  const shouldApplyChanges = autoApplyEnabled || !finishedInitialRender;
+  const applyChangesCounter = useLensSelector(selectApplyChangesCounter);
+
+  const triggerApply = applyChangesCounter !== lastApplyChangesCounter;
+  lastApplyChangesCounter = applyChangesCounter;
+
+  const shouldApplyChanges = autoApplyEnabled || !finishedInitialRender || triggerApply;
 
   const [expressionToRender, setExpressionToRender] = useState<string | null | undefined>();
 

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel_wrapper.test.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel_wrapper.test.tsx
@@ -15,7 +15,9 @@ import {
   selectAutoApplyEnabled,
   updateVisualizationState,
   disableAutoApply,
+  selectTriggerApplyChanges,
 } from '../../../state_management';
+import { setChangesApplied } from '../../../state_management/lens_slice';
 
 describe('workspace_panel_wrapper', () => {
   let mockVisualization: jest.Mocked<Visualization>;
@@ -168,11 +170,18 @@ describe('workspace_panel_wrapper', () => {
           newState: { something: 'changed' },
         })
       );
+      // simulate workspace panel behavior
+      store.dispatch(setChangesApplied(false));
       harness.update();
 
       expect(harness.applyChangesDisabled).toBeFalsy();
 
       harness.applyChanges();
+
+      expect(selectTriggerApplyChanges(store.getState())).toBeTruthy();
+      // simulate workspace panel behavior
+      store.dispatch(setChangesApplied(true));
+      harness.update();
 
       expect(harness.applyChangesDisabled).toBeTruthy();
     });
@@ -186,6 +195,7 @@ describe('workspace_panel_wrapper', () => {
           newState: { something: 'changed' },
         })
       );
+      store.dispatch(setChangesApplied(false)); // simulate workspace panel behavior
       harness.update();
 
       expect(harness.applyChangesDisabled).toBeFalsy();

--- a/x-pack/plugins/lens/public/state_management/lens_slice.ts
+++ b/x-pack/plugins/lens/public/state_management/lens_slice.ts
@@ -212,10 +212,10 @@ export const makeLensReducer = (storeDeps: LensStoreDeps) => {
     },
     [enableAutoApply.type]: (state) => {
       state.autoApplyDisabled = false;
-      state.changesApplied = true;
     },
     [disableAutoApply.type]: (state) => {
       state.autoApplyDisabled = true;
+      state.changesApplied = true;
     },
     [applyChanges.type]: (state) => {
       if (typeof state.applyChangesCounter === 'undefined') {

--- a/x-pack/plugins/lens/public/state_management/lens_slice.ts
+++ b/x-pack/plugins/lens/public/state_management/lens_slice.ts
@@ -212,6 +212,7 @@ export const makeLensReducer = (storeDeps: LensStoreDeps) => {
     },
     [enableAutoApply.type]: (state) => {
       state.autoApplyDisabled = false;
+      state.changesApplied = true;
     },
     [disableAutoApply.type]: (state) => {
       state.autoApplyDisabled = true;

--- a/x-pack/plugins/lens/public/state_management/lens_slice.ts
+++ b/x-pack/plugins/lens/public/state_management/lens_slice.ts
@@ -7,7 +7,7 @@
 
 import { createAction, createReducer, current, PayloadAction } from '@reduxjs/toolkit';
 import { VisualizeFieldContext } from 'src/plugins/ui_actions/public';
-import { cloneDeep, mapValues } from 'lodash';
+import { mapValues } from 'lodash';
 import { History } from 'history';
 import { LensEmbeddableInput } from '..';
 import { getDatasourceLayers } from '../editor_frame_service/editor_frame';
@@ -85,8 +85,8 @@ export const onActiveDataChange = createAction<TableInspectorAdapter>('lens/onAc
 export const setSaveable = createAction<boolean>('lens/setSaveable');
 export const enableAutoApply = createAction<void>('lens/enableAutoApply');
 export const disableAutoApply = createAction<void>('lens/disableAutoApply');
-// this action is only relevant when auto-apply is disabled
 export const applyChanges = createAction<void>('lens/applyChanges');
+export const setChangesApplied = createAction<boolean>('lens/setChangesApplied');
 export const updateState = createAction<{
   updater: (prevState: LensAppState) => LensAppState;
 }>('lens/updateState');
@@ -169,6 +169,7 @@ export const lensActions = {
   enableAutoApply,
   disableAutoApply,
   applyChanges,
+  setChangesApplied,
   updateState,
   updateDatasourceState,
   updateVisualizationState,
@@ -186,14 +187,6 @@ export const lensActions = {
   removeOrClearLayer,
   addLayer,
   setLayerDefaultDimension,
-};
-
-const buildAppliedState = (state: LensAppState) => {
-  return {
-    activeDatasourceId: state.activeDatasourceId,
-    visualization: cloneDeep(state.visualization),
-    datasourceStates: cloneDeep(state.datasourceStates),
-  };
 };
 
 export const makeLensReducer = (storeDeps: LensStoreDeps) => {
@@ -218,15 +211,19 @@ export const makeLensReducer = (storeDeps: LensStoreDeps) => {
       };
     },
     [enableAutoApply.type]: (state) => {
-      delete state.appliedState;
+      state.applyChangesDisabled = false;
     },
     [disableAutoApply.type]: (state) => {
-      state.appliedState = buildAppliedState(state);
+      state.applyChangesDisabled = true;
     },
     [applyChanges.type]: (state) => {
-      if (state.appliedState) {
-        state.appliedState = buildAppliedState(state);
+      if (typeof state.applyChangesCounter === 'undefined') {
+        state.applyChangesCounter = 0;
       }
+      state.applyChangesCounter!++;
+    },
+    [setChangesApplied.type]: (state, { payload: applied }) => {
+      state.changesApplied = applied;
     },
     [updateState.type]: (
       state,

--- a/x-pack/plugins/lens/public/state_management/lens_slice.ts
+++ b/x-pack/plugins/lens/public/state_management/lens_slice.ts
@@ -211,10 +211,10 @@ export const makeLensReducer = (storeDeps: LensStoreDeps) => {
       };
     },
     [enableAutoApply.type]: (state) => {
-      state.applyChangesDisabled = false;
+      state.autoApplyDisabled = false;
     },
     [disableAutoApply.type]: (state) => {
-      state.applyChangesDisabled = true;
+      state.autoApplyDisabled = true;
     },
     [applyChanges.type]: (state) => {
       if (typeof state.applyChangesCounter === 'undefined') {

--- a/x-pack/plugins/lens/public/state_management/selectors.test.ts
+++ b/x-pack/plugins/lens/public/state_management/selectors.test.ts
@@ -5,32 +5,45 @@
  * 2.0.
  */
 
-import { LensAppState, selectApplyChangesCounter, selectChangesApplied } from '.';
+import { LensAppState, selectTriggerApplyChanges, selectChangesApplied } from '.';
 
 describe('lens selectors', () => {
   describe('selecting changes applied', () => {
-    it('should be true when flag is set', () => {
+    it('should be true when auto-apply disabled and flag is set', () => {
       const lensState = {
         changesApplied: true,
+        autoApplyDisabled: true,
       } as Partial<LensAppState>;
 
       expect(selectChangesApplied({ lens: lensState as LensAppState })).toBeTruthy();
     });
 
-    it('should be false when flag is not set', () => {
+    it('should be false when auto-apply disabled and flag is false', () => {
       const lensState = {
         changesApplied: false,
+        autoApplyDisabled: true,
       } as Partial<LensAppState>;
 
       expect(selectChangesApplied({ lens: lensState as LensAppState })).toBeFalsy();
     });
+
+    it('should be true when auto-apply enabled no matter what', () => {
+      const lensState = {
+        changesApplied: false,
+        autoApplyDisabled: false,
+      } as Partial<LensAppState>;
+
+      expect(selectChangesApplied({ lens: lensState as LensAppState })).toBeTruthy();
+    });
   });
-  it('should select apply changes counter', () => {
+  it('should select apply changes trigger', () => {
+    selectTriggerApplyChanges({ lens: { applyChangesCounter: 1 } as LensAppState }); // get the counters in sync
+
     expect(
-      selectApplyChangesCounter({ lens: { applyChangesCounter: undefined } as LensAppState })
-    ).toBe(0);
-    expect(selectApplyChangesCounter({ lens: { applyChangesCounter: 21 } as LensAppState })).toBe(
-      21
-    );
+      selectTriggerApplyChanges({ lens: { applyChangesCounter: 2 } as LensAppState })
+    ).toBeTruthy();
+    expect(
+      selectTriggerApplyChanges({ lens: { applyChangesCounter: 2 } as LensAppState })
+    ).toBeFalsy();
   });
 });

--- a/x-pack/plugins/lens/public/state_management/selectors.test.ts
+++ b/x-pack/plugins/lens/public/state_management/selectors.test.ts
@@ -5,114 +5,32 @@
  * 2.0.
  */
 
-import { LensAppState, selectAppliedState, selectChangesApplied } from '.';
+import { LensAppState, selectApplyChangesCounter, selectChangesApplied } from '.';
 
 describe('lens selectors', () => {
-  it('should select applied state', () => {
-    const lensState = {
-      appliedState: {
-        activeDatasourceId: 'foobar',
-        visualization: {
-          activeId: 'some-id',
-          state: {},
-        },
-        datasourceStates: {
-          indexpattern: {
-            isLoading: false,
-            state: {},
-          },
-        },
-      },
-    } as Partial<LensAppState>;
-
-    expect(selectAppliedState({ lens: lensState as LensAppState })).toStrictEqual(
-      lensState.appliedState
-    );
-  });
-
   describe('selecting changes applied', () => {
-    it('should be true when applied state matches working state', () => {
+    it('should be true when flag is set', () => {
       const lensState = {
-        activeDatasourceId: 'foobar',
-        visualization: {
-          activeId: 'some-id',
-          state: {},
-        },
-        datasourceStates: {
-          indexpattern: {
-            isLoading: false,
-            state: {},
-          },
-        },
-        appliedState: {
-          activeDatasourceId: 'foobar',
-          visualization: {
-            activeId: 'some-id',
-            state: {},
-          },
-          datasourceStates: {
-            indexpattern: {
-              isLoading: false,
-              state: {},
-            },
-          },
-        },
+        changesApplied: true,
       } as Partial<LensAppState>;
 
       expect(selectChangesApplied({ lens: lensState as LensAppState })).toBeTruthy();
     });
 
-    it('should be true when no applied state (auto-apply enabled)', () => {
+    it('should be false when flag is not set', () => {
       const lensState = {
-        visualization: {
-          activeId: 'some-id',
-          state: {},
-        },
-        datasourceStates: {
-          indexpattern: {
-            isLoading: false,
-            state: {},
-          },
-        },
-        appliedState: undefined,
+        changesApplied: false,
       } as Partial<LensAppState>;
-
-      expect(selectChangesApplied({ lens: lensState as LensAppState })).toBeTruthy();
-    });
-
-    it('should be false when applied state differs from working state', () => {
-      const lensState = {
-        activeDatasourceId: 'foobar',
-        visualization: {
-          activeId: 'some-other-id',
-          state: {
-            something: 'changed',
-          },
-        },
-        datasourceStates: {
-          indexpattern: {
-            isLoading: false,
-            state: {
-              something: 'changed',
-            },
-          },
-        },
-        appliedState: {
-          activeDatasourceId: 'foobar',
-          visualization: {
-            activeId: 'some-id',
-            state: {},
-          },
-          datasourceStates: {
-            indexpattern: {
-              isLoading: false,
-              state: {},
-            },
-          },
-        },
-      } as unknown as LensAppState;
 
       expect(selectChangesApplied({ lens: lensState as LensAppState })).toBeFalsy();
     });
+  });
+  it('should select apply changes counter', () => {
+    expect(
+      selectApplyChangesCounter({ lens: { applyChangesCounter: undefined } as LensAppState })
+    ).toBe(0);
+    expect(selectApplyChangesCounter({ lens: { applyChangesCounter: 21 } as LensAppState })).toBe(
+      21
+    );
   });
 });

--- a/x-pack/plugins/lens/public/state_management/selectors.ts
+++ b/x-pack/plugins/lens/public/state_management/selectors.ts
@@ -21,7 +21,7 @@ export const selectVisualization = (state: LensState) => state.lens.visualizatio
 export const selectStagedPreview = (state: LensState) => state.lens.stagedPreview;
 export const selectAutoApplyEnabled = (state: LensState) => !state.lens.applyChangesDisabled;
 export const selectChangesApplied = (state: LensState) => Boolean(state.lens.changesApplied);
-export const selectApplyChangesCounter = (state: LensState) => state.lens.applyChangesCounter;
+export const selectApplyChangesCounter = (state: LensState) => state.lens.applyChangesCounter || 0;
 export const selectDatasourceStates = (state: LensState) => state.lens.datasourceStates;
 export const selectActiveDatasourceId = (state: LensState) => state.lens.activeDatasourceId;
 export const selectActiveData = (state: LensState) => state.lens.activeData;

--- a/x-pack/plugins/lens/public/state_management/selectors.ts
+++ b/x-pack/plugins/lens/public/state_management/selectors.ts
@@ -8,9 +8,8 @@
 import { createSelector } from '@reduxjs/toolkit';
 import { SavedObjectReference } from 'kibana/server';
 import { FilterManager } from 'src/plugins/data/public';
-import { isEqual } from 'lodash';
 import { LensState } from './types';
-import { Datasource, DatasourceMap, FramePublicAPI, VisualizationMap } from '../types';
+import { Datasource, DatasourceMap, VisualizationMap } from '../types';
 import { getDatasourceLayers } from '../editor_frame_service/editor_frame';
 
 export const selectPersistedDoc = (state: LensState) => state.lens.persistedDoc;
@@ -20,27 +19,14 @@ export const selectFilters = (state: LensState) => state.lens.filters;
 export const selectResolvedDateRange = (state: LensState) => state.lens.resolvedDateRange;
 export const selectVisualization = (state: LensState) => state.lens.visualization;
 export const selectStagedPreview = (state: LensState) => state.lens.stagedPreview;
-export const selectAppliedState = (state: LensState) => state.lens.appliedState;
+export const selectAutoApplyEnabled = (state: LensState) => !state.lens.applyChangesDisabled;
+export const selectChangesApplied = (state: LensState) => Boolean(state.lens.changesApplied);
+export const selectApplyChangesCounter = (state: LensState) => state.lens.applyChangesCounter;
 export const selectDatasourceStates = (state: LensState) => state.lens.datasourceStates;
 export const selectActiveDatasourceId = (state: LensState) => state.lens.activeDatasourceId;
 export const selectActiveData = (state: LensState) => state.lens.activeData;
 export const selectIsFullscreenDatasource = (state: LensState) =>
   Boolean(state.lens.isFullscreenDatasource);
-
-export const selectChangesApplied = createSelector(
-  [selectAppliedState, selectVisualization, selectDatasourceStates, selectActiveDatasourceId],
-  (appliedState, visualization, datasourceStates, activeDatasourceId) => {
-    if (!appliedState) return true; // auto-apply is enabled
-
-    const workingState = { activeDatasourceId, visualization, datasourceStates };
-    return isEqual(appliedState, workingState);
-  }
-);
-
-export const selectAutoApplyEnabled = createSelector(
-  [selectAppliedState],
-  (appliedState) => !Boolean(appliedState)
-);
 
 export const selectExecutionContext = createSelector(
   [selectQuery, selectFilters, selectResolvedDateRange],
@@ -167,23 +153,13 @@ export const selectDatasourceLayers = createSelector(
 export const selectFramePublicAPI = createSelector(
   [
     selectDatasourceStates,
-    selectAppliedState,
     selectActiveData,
     selectInjectedDependencies as SelectInjectedDependenciesFunction<DatasourceMap>,
   ],
-  (datasourceStates, appliedState, activeData, datasourceMap) => {
-    const api: FramePublicAPI = {
+  (datasourceStates, activeData, datasourceMap) => {
+    return {
       datasourceLayers: getDatasourceLayers(datasourceStates, datasourceMap),
       activeData,
     };
-
-    if (appliedState) {
-      api.appliedDatasourceLayers = getDatasourceLayers(
-        appliedState.datasourceStates,
-        datasourceMap
-      );
-    }
-
-    return api;
   }
 );

--- a/x-pack/plugins/lens/public/state_management/selectors.ts
+++ b/x-pack/plugins/lens/public/state_management/selectors.ts
@@ -19,7 +19,7 @@ export const selectFilters = (state: LensState) => state.lens.filters;
 export const selectResolvedDateRange = (state: LensState) => state.lens.resolvedDateRange;
 export const selectVisualization = (state: LensState) => state.lens.visualization;
 export const selectStagedPreview = (state: LensState) => state.lens.stagedPreview;
-export const selectAutoApplyEnabled = (state: LensState) => !state.lens.applyChangesDisabled;
+export const selectAutoApplyEnabled = (state: LensState) => !state.lens.autoApplyDisabled;
 export const selectChangesApplied = (state: LensState) => Boolean(state.lens.changesApplied);
 export const selectApplyChangesCounter = (state: LensState) => state.lens.applyChangesCounter || 0;
 export const selectDatasourceStates = (state: LensState) => state.lens.datasourceStates;

--- a/x-pack/plugins/lens/public/state_management/selectors.ts
+++ b/x-pack/plugins/lens/public/state_management/selectors.ts
@@ -20,13 +20,20 @@ export const selectResolvedDateRange = (state: LensState) => state.lens.resolved
 export const selectVisualization = (state: LensState) => state.lens.visualization;
 export const selectStagedPreview = (state: LensState) => state.lens.stagedPreview;
 export const selectAutoApplyEnabled = (state: LensState) => !state.lens.autoApplyDisabled;
-export const selectChangesApplied = (state: LensState) => Boolean(state.lens.changesApplied);
-export const selectApplyChangesCounter = (state: LensState) => state.lens.applyChangesCounter || 0;
+export const selectChangesApplied = (state: LensState) =>
+  !state.lens.autoApplyDisabled || Boolean(state.lens.changesApplied);
 export const selectDatasourceStates = (state: LensState) => state.lens.datasourceStates;
 export const selectActiveDatasourceId = (state: LensState) => state.lens.activeDatasourceId;
 export const selectActiveData = (state: LensState) => state.lens.activeData;
 export const selectIsFullscreenDatasource = (state: LensState) =>
   Boolean(state.lens.isFullscreenDatasource);
+
+let applyChangesCounter: number | undefined;
+export const selectTriggerApplyChanges = (state: LensState) => {
+  const shouldApply = state.lens.applyChangesCounter !== applyChangesCounter;
+  applyChangesCounter = state.lens.applyChangesCounter;
+  return shouldApply;
+};
 
 export const selectExecutionContext = createSelector(
   [selectQuery, selectFilters, selectResolvedDateRange],

--- a/x-pack/plugins/lens/public/state_management/types.ts
+++ b/x-pack/plugins/lens/public/state_management/types.ts
@@ -33,7 +33,7 @@ export interface PreviewState {
 export interface EditorFrameState extends PreviewState {
   activeDatasourceId: string | null;
   stagedPreview?: PreviewState;
-  applyChangesDisabled?: boolean;
+  autoApplyDisabled?: boolean;
   applyChangesCounter?: number;
   changesApplied?: boolean;
   isFullscreenDatasource?: boolean;

--- a/x-pack/plugins/lens/public/state_management/types.ts
+++ b/x-pack/plugins/lens/public/state_management/types.ts
@@ -30,15 +30,12 @@ export interface PreviewState {
   visualization: VisualizationState;
   datasourceStates: DatasourceStates;
 }
-export interface AppliedState {
-  activeDatasourceId: EditorFrameState['activeDatasourceId'];
-  visualization: VisualizationState;
-  datasourceStates: DatasourceStates;
-}
 export interface EditorFrameState extends PreviewState {
   activeDatasourceId: string | null;
   stagedPreview?: PreviewState;
-  appliedState?: AppliedState;
+  applyChangesDisabled?: boolean;
+  applyChangesCounter?: number;
+  changesApplied?: boolean;
   isFullscreenDatasource?: boolean;
 }
 export interface LensAppState extends EditorFrameState {


### PR DESCRIPTION
Changing from duplicating state to expression caching in the workspace panel.
