### PR TITLE
revert defer() workaround

### DIFF
--- a/src/plugins/vis_type_script/public/kibana_api/kibana_api.ts
+++ b/src/plugins/vis_type_script/public/kibana_api/kibana_api.ts
@@ -15,9 +15,11 @@ export interface VisTypeScriptKibanaApiDeps {
   data: DataPublicPluginStart;
 }
 
-export interface SearchOptions {
+export interface EsSearchOptions {
   useKibanaContext: boolean;
 }
+export type ESSearchRequest = estypes.SearchRequest;
+export type ESSearchResponse = estypes.SearchResponse;
 
 export class VisTypeScriptKibanaApi {
   constructor(
@@ -26,9 +28,9 @@ export class VisTypeScriptKibanaApi {
   ) {}
 
   async esSearch(
-    payload: estypes.SearchRequest,
-    { useKibanaContext = true }: SearchOptions = { useKibanaContext: true }
-  ): Promise<estypes.SearchResponse> {
+    payload: ESSearchRequest,
+    { useKibanaContext = true }: EsSearchOptions = { useKibanaContext: true }
+  ): Promise<ESSearchResponse> {
     if (useKibanaContext) {
       // TODO: adjust request based on this.visSearchContext
       // eslint-disable-next-line no-console


### PR DESCRIPTION
## Summary

This seem to do everything we need, for example:


```
const result = await KIBANA.searchEs({});
console.log(result.hits.hits)
```

Not sure if I am missing something




### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
